### PR TITLE
fix(inference): correct DeepISLES Docker volume mounts and CLI args

### DIFF
--- a/src/stroke_deepisles_demo/inference/deepisles.py
+++ b/src/stroke_deepisles_demo/inference/deepisles.py
@@ -154,12 +154,13 @@ def _run_via_docker(
         command.extend(["--flair_file_name", "flair.nii.gz"])
 
     if fast:
-        command.extend(["--fast", "True"])
+        command.append("--fast")
 
     # Set up volume mounts
+    # DeepISLES expects input files at /app/data/ and outputs to /app/output/
     volumes = {
-        input_dir.resolve(): "/input",
-        output_dir.resolve(): "/output",
+        input_dir.resolve(): "/app/data",
+        output_dir.resolve(): "/app/output",
     }
 
     logger.info("Running DeepISLES via Docker: input=%s, fast=%s, gpu=%s", input_dir, fast, gpu)


### PR DESCRIPTION
## Summary
- Fixed `--fast` CLI argument: changed from `--fast True` to `--fast` (flag-style argument expected by DeepISLES)
- Fixed Docker volume mounts: changed from `/input`, `/output` to `/app/data`, `/app/output` (DeepISLES expected paths)
- Added graceful skip in integration test when GPU/nvidia-smi unavailable

## Context
These bugs were discovered during Docker integration testing with Colima (headless Docker runtime). The previous implementation would fail with:

1. `main.py: error: unrecognized arguments: True` - DeepISLES CLI expects `--fast` as a boolean flag
2. `FileNotFoundError: /app/data/dwi.nii.gz does not exist` - DeepISLES internally looks for files at `/app/data/`

## Test plan
- [x] All unit tests pass (103 tests)
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass
- [ ] Integration test runs to DeepISLES container (skips gracefully on non-GPU machines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Docker volume mount paths to align with DeepISLES container specifications.
  * Enhanced GPU error detection and handling, automatically skipping tests when GPU drivers are unavailable.
  * Updated Docker argument format for fast mode processing.

* **Tests**
  * Added GPU requirement tracking in integration tests for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->