### PR TITLE
fix(pipeline): prevent unbounded disk usage from HuggingFace temp files

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ class TestCli:
         result = PipelineResult(
             case_id="sub-001",
             input_files=MagicMock(),
-            staged_dir=MagicMock(),
+            results_dir=MagicMock(),
             prediction_mask=MagicMock(),
             ground_truth=None,
             dice_score=None,
@@ -50,7 +50,7 @@ class TestCli:
         result = PipelineResult(
             case_id="sub-001",
             input_files=MagicMock(),
-            staged_dir=MagicMock(),
+            results_dir=MagicMock(),
             prediction_mask=MagicMock(),
             ground_truth=None,
             dice_score=None,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -35,20 +35,18 @@ class TestRunPipelineOnCase:
             # Configure mocks
             mock_dataset = MagicMock()
 
-            # Create real temp files for ground truth (context manager cleans up HF temp files)
+            # Create real temp files (pipeline copies these to results_dir)
+            dwi_file = temp_dir / "dwi_mock.nii.gz"
+            dwi_file.write_bytes(b"fake dwi nifti")
+            adc_file = temp_dir / "adc_mock.nii.gz"
+            adc_file.write_bytes(b"fake adc nifti")
             gt_file = temp_dir / "gt_mock.nii.gz"
-            gt_file.write_bytes(b"fake nifti")
-
-            # Mock paths that "exist"
-            dwi_path = MagicMock(spec=Path)
-            dwi_path.exists.return_value = True
-            adc_path = MagicMock(spec=Path)
-            adc_path.exists.return_value = True
+            gt_file.write_bytes(b"fake gt nifti")
 
             mock_dataset.get_case.return_value = CaseFiles(
-                dwi=dwi_path,
-                adc=adc_path,
-                ground_truth=gt_file,  # Use real file for copy operation
+                dwi=dwi_file,
+                adc=adc_file,
+                ground_truth=gt_file,
                 # flair omitted
             )
             # Support context manager protocol: with load_isles_dataset() as dataset:
@@ -146,17 +144,18 @@ class TestRunPipelineOnCase:
     def test_handles_missing_ground_truth(
         self,
         mock_dependencies: dict[str, MagicMock],
-        temp_dir: Path,  # noqa: ARG002
+        temp_dir: Path,
     ) -> None:
         """Handles cases without ground truth gracefully."""
-        # Modify mock to return no ground truth
-        dwi = MagicMock(spec=Path)
-        dwi.exists.return_value = True
-        adc = MagicMock(spec=Path)
-        adc.exists.return_value = True
+        # Create real files for DWI/ADC (pipeline copies these)
+        dwi_file = temp_dir / "dwi_no_gt.nii.gz"
+        dwi_file.write_bytes(b"fake dwi")
+        adc_file = temp_dir / "adc_no_gt.nii.gz"
+        adc_file.write_bytes(b"fake adc")
+
         mock_dependencies["dataset"].get_case.return_value = CaseFiles(
-            dwi=dwi,
-            adc=adc,
+            dwi=dwi_file,
+            adc=adc_file,
             # ground_truth omitted
         )
 
@@ -237,7 +236,7 @@ class TestRunPipelineOnBatch:
                 PipelineResult(
                     case_id="sub-001",
                     input_files=MagicMock(),
-                    staged_dir=MagicMock(),
+                    results_dir=MagicMock(),
                     prediction_mask=MagicMock(),
                     ground_truth=None,
                     dice_score=0.8,
@@ -246,7 +245,7 @@ class TestRunPipelineOnBatch:
                 PipelineResult(
                     case_id="sub-002",
                     input_files=MagicMock(),
-                    staged_dir=MagicMock(),
+                    results_dir=MagicMock(),
                     prediction_mask=MagicMock(),
                     ground_truth=None,
                     dice_score=0.9,
@@ -267,7 +266,7 @@ class TestRunPipelineOnBatch:
             mock_run.return_value = PipelineResult(
                 case_id="sub-001",
                 input_files=MagicMock(),
-                staged_dir=MagicMock(),
+                results_dir=MagicMock(),
                 prediction_mask=MagicMock(),
                 ground_truth=None,
                 dice_score=0.8,

--- a/tests/test_pipeline_cleanup.py
+++ b/tests/test_pipeline_cleanup.py
@@ -4,8 +4,13 @@ from unittest.mock import MagicMock, patch
 from stroke_deepisles_demo.pipeline import run_pipeline_on_case
 
 
-def test_pipeline_cleanup_default() -> None:
+def test_pipeline_cleanup_default(temp_dir: Path) -> None:
     """Test that pipeline cleans up staging directory by default."""
+    # Create real files (pipeline now copies input files to results_dir)
+    dwi_file = temp_dir / "dwi.nii.gz"
+    dwi_file.write_bytes(b"fake dwi")
+    adc_file = temp_dir / "adc.nii.gz"
+    adc_file.write_bytes(b"fake adc")
 
     # Mock everything to avoid running actual heavy inference
     with (
@@ -13,13 +18,13 @@ def test_pipeline_cleanup_default() -> None:
         patch("stroke_deepisles_demo.pipeline.stage_case_for_deepisles") as mock_stage,
         patch("stroke_deepisles_demo.pipeline.run_deepisles_on_folder") as mock_run,
         patch("stroke_deepisles_demo.pipeline.metrics.compute_dice"),
-        patch("shutil.rmtree") as mock_rmtree,
+        patch("stroke_deepisles_demo.pipeline.shutil.rmtree") as mock_rmtree,
     ):
         # Setup mocks
         mock_dataset = MagicMock()
         mock_dataset.list_case_ids.return_value = ["case1"]
-        # Return dict without ground_truth to avoid file copy attempt
-        mock_dataset.get_case.return_value = {"dwi": Path("dwi.nii.gz"), "adc": Path("adc.nii.gz")}
+        # Return dict with real files (no ground_truth)
+        mock_dataset.get_case.return_value = {"dwi": dwi_file, "adc": adc_file}
 
         # Support context manager protocol: with load_isles_dataset() as dataset:
         mock_load.return_value.__enter__ = MagicMock(return_value=mock_dataset)
@@ -36,7 +41,7 @@ def test_pipeline_cleanup_default() -> None:
         # Run pipeline with defaults (cleanup_staging=True is the default)
         run_pipeline_on_case("case1")
 
-        # Verify that rmtree was called
+        # Verify that rmtree was called (for staging cleanup)
         assert mock_rmtree.called
 
         # Get the path passed to stage_case_for_deepisles

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -51,7 +51,7 @@ def test_run_segmentation_logic() -> None:
     mock_result = PipelineResult(
         case_id="sub-001",
         input_files={"dwi": MagicMock(), "adc": MagicMock()},
-        staged_dir=MagicMock(),
+        results_dir=MagicMock(),
         prediction_mask=MagicMock(),
         ground_truth=MagicMock(),
         dice_score=0.85,


### PR DESCRIPTION
## Summary

**CRITICAL FIX for HuggingFace Spaces deployment.**

Fixes a resource leak in `run_pipeline_on_case()` that would cause HuggingFace Spaces to crash with disk quota errors after a few inference runs.

### Problem
- `load_isles_dataset()` creates `HuggingFaceDataset` instances that write NIfTI files (~50-100MB) to temp directories
- The dataset's `cleanup()` method was never called
- Each inference run accumulated temp files without cleanup
- On HF Spaces, this would rapidly fill the ephemeral disk storage

### Solution
- Use context manager: `with load_isles_dataset() as dataset:`
- Copy ground_truth to results_dir before dataset cleanup (needed for Dice computation)
- Dataset temp files are now automatically cleaned up via `__exit__`

### Changes
- `pipeline.py`: Wrap dataset usage in context manager, copy ground_truth before cleanup
- `test_pipeline.py`: Update mocks to support context manager protocol
- `test_pipeline_cleanup.py`: Update mocks to support context manager protocol

## Test plan
- [x] All 125 tests pass
- [x] ruff clean
- [x] mypy clean
- [ ] Manual verification on local Docker build (optional)
- [ ] Deploy to HF Spaces and verify no disk quota errors after multiple runs