### PR TITLE
fix(ui): use lazy imports to avoid RuntimeWarning on startup

### DIFF
--- a/src/stroke_deepisles_demo/ui/__init__.py
+++ b/src/stroke_deepisles_demo/ui/__init__.py
@@ -1,5 +1,20 @@
-"""UI module for stroke-deepisles-demo."""
+"""UI module for stroke-deepisles-demo.
 
-from stroke_deepisles_demo.ui.app import create_app, get_demo
+Exports:
+    create_app: Create the Gradio application
+    get_demo: Get the global demo instance (lazy initialization)
+"""
+
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import to avoid circular import when running as `python -m`."""
+    if name in ("create_app", "get_demo"):
+        from stroke_deepisles_demo.ui.app import create_app, get_demo
+
+        return {"create_app": create_app, "get_demo": get_demo}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["create_app", "get_demo"]


### PR DESCRIPTION
## Summary
- Fix RuntimeWarning when running `python -m stroke_deepisles_demo.ui.app`
- Use `__getattr__` lazy imports in `ui/__init__.py`

## Problem
When the UI module runs as `python -m`, Python imports the package first, triggering the `__init__.py` which tried to import from `ui.app` before it executed as `__main__`:
```
RuntimeWarning: 'stroke_deepisles_demo.ui.app' found in sys.modules 
after import of package 'stroke_deepisles_demo.ui', but prior to execution
```

## Solution
Use Python's `__getattr__` for module-level lazy imports. This defers the import until the attributes are actually accessed.

## Test plan
- [x] All 125 tests pass locally
- [x] Import works: `from stroke_deepisles_demo.ui import create_app, get_demo`
- [x] Lint and type checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized module initialization for improved performance through lazy loading of core functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->