### PR TITLE
fix(docker): use subprocess bridge for Python version isolation

### DIFF
--- a/scripts/deepisles_adapter.py
+++ b/scripts/deepisles_adapter.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""DeepISLES adapter script for subprocess invocation.
+
+This script runs inside the isles_ensemble conda environment (Python 3.8)
+and is called by our Gradio app (Python 3.10+) via subprocess.
+
+Usage:
+    conda run -n isles_ensemble python scripts/deepisles_adapter.py \
+        --dwi /path/to/dwi.nii.gz \
+        --adc /path/to/adc.nii.gz \
+        --output /path/to/output \
+        [--flair /path/to/flair.nii.gz] \
+        [--fast]
+
+Note: This script intentionally uses Python 3.8 compatible syntax and
+os.path functions (not pathlib) for compatibility with DeepISLES environment.
+"""
+
+import argparse
+import os
+import sys
+
+# Add DeepISLES to path
+sys.path.insert(0, "/app")
+
+from src.isles22_ensemble import IslesEnsemble
+
+
+def main() -> None:
+    """Run DeepISLES inference with command-line arguments."""
+    parser = argparse.ArgumentParser(description="DeepISLES inference adapter")
+    parser.add_argument("--dwi", required=True, help="Path to DWI NIfTI file")
+    parser.add_argument("--adc", required=True, help="Path to ADC NIfTI file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--flair", default=None, help="Path to FLAIR NIfTI file")
+    parser.add_argument("--fast", action="store_true", help="Fast mode (SEALS only)")
+    parser.add_argument("--ensemble-path", default="/app", help="Path to DeepISLES repo")
+
+    args = parser.parse_args()
+
+    # Validate inputs exist (using os.path for Py3.8 compatibility)
+    if not os.path.exists(args.dwi):  # noqa: PTH110
+        print(f"ERROR: DWI file not found: {args.dwi}", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.exists(args.adc):  # noqa: PTH110
+        print(f"ERROR: ADC file not found: {args.adc}", file=sys.stderr)
+        sys.exit(1)
+    if args.flair and not os.path.exists(args.flair):  # noqa: PTH110
+        print(f"ERROR: FLAIR file not found: {args.flair}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create output directory (using os.makedirs for Py3.8 compatibility)
+    os.makedirs(args.output, exist_ok=True)  # noqa: PTH103
+
+    # Run inference
+    print("Running DeepISLES inference...")
+    print(f"  DWI: {args.dwi}")
+    print(f"  ADC: {args.adc}")
+    print(f"  FLAIR: {args.flair}")
+    print(f"  Output: {args.output}")
+    print(f"  Fast mode: {args.fast}")
+
+    stroke_segm = IslesEnsemble()
+    stroke_segm.predict_ensemble(
+        ensemble_path=args.ensemble_path,
+        input_dwi_path=args.dwi,
+        input_adc_path=args.adc,
+        input_flair_path=args.flair,
+        output_path=args.output,
+        fast=args.fast,
+        skull_strip=False,
+        save_team_outputs=False,
+        results_mni=False,
+        parallelize=True,
+    )
+
+    print(f"DeepISLES inference complete. Output: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/inference/test_direct.py
+++ b/tests/inference/test_direct.py
@@ -143,9 +143,7 @@ class TestRunDeepISLESDirect:
         with pytest.raises(MissingInputError):
             run_deepisles_direct(dwi, adc, output)
 
-    def test_deepisles_not_available_raises(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_deepisles_not_available_raises(self, tmp_path: Path) -> None:
         """Raises DeepISLESError when DeepISLES not available."""
         from stroke_deepisles_demo.inference.direct import run_deepisles_direct
 
@@ -156,8 +154,7 @@ class TestRunDeepISLESDirect:
         dwi.touch()
         adc.touch()
 
-        # Ensure DeepISLES is not importable
-        monkeypatch.delenv("DEEPISLES_DIRECT_INVOCATION", raising=False)
-
-        with pytest.raises(DeepISLESError, match="DeepISLES modules not found"):
+        # Subprocess will fail because conda/adapter not available locally
+        # The error message depends on what's missing (conda, /app dir, etc.)
+        with pytest.raises(DeepISLESError, match=r"(subprocess|conda|No such file)"):
             run_deepisles_direct(dwi, adc, output)


### PR DESCRIPTION
## Summary

DeepISLES requires Python 3.8 (conda env), but Gradio 6 needs Python 3.10+. They cannot coexist in the same Python process.

## Root Cause (Found by Auditing Reference Repo)

The `isleschallenge/deepisles` Docker image:
- Uses **conda environment** `isles_ensemble` with Python 3.8.0
- PyTorch 1.11.0 and nnU-Net dependencies are ONLY in that conda env
- Our attempt to install Gradio 6 into Python 3.8 fails (`BUILD_ERROR`)

## Solution: Shell Out Architecture

```
┌─────────────────────────────────────────────────────────────┐
│  Gradio App (System Python 3.10+)                          │
│  - Modern dependencies (Gradio 6, numpy 1.26, etc.)        │
│  - Handles UI, data loading, visualization                 │
└─────────────────────┬───────────────────────────────────────┘
                      │ subprocess.run()
                      ▼
┌─────────────────────────────────────────────────────────────┐
│  conda run -n isles_ensemble python /app/deepisles_adapter.py│
│  - Python 3.8 environment                                   │
│  - PyTorch 1.11, nnU-Net, DeepISLES                        │
│  - Runs actual inference                                    │
└─────────────────────────────────────────────────────────────┘
```

## Changes

1. **Dockerfile** - Install deps to system Python (not conda env)
2. **direct.py** - Rewritten to use `subprocess` + `conda run`
3. **scripts/deepisles_adapter.py** - New adapter script for subprocess invocation
4. **tests** - Updated error message expectations

## Test Plan

- [x] All 130 unit tests pass locally
- [x] Pre-commit hooks pass
- [ ] Deploy to HF Spaces and verify Docker builds
- [ ] Run inference end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured DeepISLES inference execution model to improve system isolation and maintainability.
  * Updated deployment container configuration for optimized dependency management.

* **Tests**
  * Updated inference tests to reflect architectural changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->