### PR TITLE
fix(hf): avoid eager 27GB dataset download on /api/cases

### DIFF
--- a/docs/bugs/BUG-014-api-cases-500-error.md
+++ b/docs/bugs/BUG-014-api-cases-500-error.md
@@ -1,0 +1,130 @@
+# BUG-014: /api/cases Returns 500 Internal Server Error
+
+**Status**: INVESTIGATING
+**Severity**: P1 (Frontend completely broken)
+**Discovered**: 2025-12-15
+**Reporter**: Manual testing
+
+## Symptoms
+
+1. Frontend shows "Loading cases..." indefinitely
+2. Backend health check returns 200 OK with healthy status
+3. GET `/api/cases` returns HTTP 500 Internal Server Error
+
+## Evidence
+
+### Backend Health (Working)
+```
+https://vibecodermcswaggins-stroke-deepisles-demo.hf.space/
+```
+Returns:
+```json
+{"status":"healthy","service":"stroke-segmentation-api","version":"2.0.0","features":["async-jobs","progress-tracking"]}
+```
+
+### Cases Endpoint (Failing)
+```
+https://vibecodermcswaggins-stroke-deepisles-demo.hf.space/api/cases
+```
+Returns: HTTP 500 Internal Server Error
+
+## Root Cause Analysis
+
+### Call Chain
+```
+GET /api/cases
+  → routes.py:get_cases()
+    → data/__init__.py:list_case_ids()
+      → data/loader.py:load_isles_dataset()
+        → datasets.load_dataset("hugging-science/isles24-stroke", ...)
+```
+
+### Dataset Status
+- **Dataset**: `hugging-science/isles24-stroke`
+- **Access**: PUBLIC (no authentication required)
+- **License**: CC BY-NC-SA 4.0
+
+### Potential Causes (In Order of Likelihood)
+
+1. ~~**Missing `datasets` Library**~~ **RULED OUT**
+   - `neuroimaging-go-brrrr` depends on `datasets>=3.4.0`
+   - HOWEVER: Uses custom uv source pinning to a git commit (not PyPI)
+   - This addresses an "embed_table_storage bug" - may still cause issues
+
+2. **neuroimaging-go-brrrr Installation Failure**
+   - Installed from git: `git+https://github.com/.../neuroimaging-go-brrrr.git@v0.2.1`
+   - Git installs in Docker can fail silently if network issues
+   - Package provides Nifti feature for datasets library
+
+3. **Memory/Storage Constraints**
+   - HF Spaces T4-small has limited RAM
+   - Loading dataset indices may exceed memory
+   - `/tmp` storage may be exhausted
+
+4. **Network Issue**
+   - HF Spaces backend can't reach HF Hub
+   - DNS resolution failure
+   - SSL certificate issue
+
+## Reproduction
+
+### Local Test
+```bash
+uv sync --extra api
+uv run python -c "from stroke_deepisles_demo.data import list_case_ids; print(list_case_ids())"
+```
+
+### HF Space Logs
+Check HF Space logs for the actual exception:
+1. Go to https://huggingface.co/spaces/VibecoderMcSwaggins/stroke-deepisles-demo
+2. Click "Logs" tab
+3. Look for Python traceback when `/api/cases` is called
+
+## Impact
+
+- Frontend is completely non-functional
+- Users cannot select cases or run segmentation
+- Backend health check gives false confidence
+
+## Recommended Investigation Steps
+
+1. **Check HF Space Logs**
+   - View actual Python exception traceback
+   - Identify if ImportError, MemoryError, or other
+
+2. **Verify Dependencies in Container**
+   ```bash
+   # SSH into space or add debug endpoint
+   pip list | grep -E "datasets|neuroimaging"
+   ```
+
+3. **Test Dataset Loading Directly**
+   - Add temporary debug endpoint to verify load_dataset works
+   - Or check if `datasets` import succeeds in lifespan handler
+
+4. **Check for Missing Dependency**
+   - If `datasets` is missing, add to pyproject.toml dependencies
+   - Rebuild and redeploy
+
+## Related Files
+
+- `src/stroke_deepisles_demo/api/routes.py:49-63` - get_cases endpoint
+- `src/stroke_deepisles_demo/data/__init__.py:34-44` - list_case_ids function
+- `src/stroke_deepisles_demo/data/loader.py:157-227` - load_isles_dataset function
+- `pyproject.toml` - dependencies (missing `datasets`?)
+
+## Immediate Next Step
+
+**CHECK THE HF SPACE LOGS** - this is the only way to confirm the actual exception.
+
+1. Go to: https://huggingface.co/spaces/VibecoderMcSwaggins/stroke-deepisles-demo
+2. Click "Logs" tab (or burger menu → "Logs")
+3. Look for Python traceback
+4. The exception will tell us exactly what's failing
+
+## Notes
+
+- This bug was NOT caused by the frontend Static SDK deployment fix
+- The backend has been returning 500 on `/api/cases` - we just didn't notice until now
+- Need HF Space logs to confirm root cause before fixing
+- Do NOT deploy fixes until root cause is confirmed from logs

--- a/docs/bugs/BUG-014-api-cases-500-error.md
+++ b/docs/bugs/BUG-014-api-cases-500-error.md
@@ -7,19 +7,26 @@
 
 ## Summary
 
-The `/api/cases` endpoint fails because it downloads the entire 27GB dataset just to return a list of 149 case IDs. This is fixable without reducing the dataset.
+The `/api/cases` endpoint failed on HF Spaces because it triggered an eager ~27GB
+dataset download/prepare step just to return a list of case IDs.
+
+The fix keeps the *full* dataset, but changes the data access pattern so:
+- `/api/cases` does **zero** dataset downloading
+- `get_case(case_id)` downloads **one** Parquet shard (one case), not the full dataset
 
 ## Root Cause
 
 **Current code path:**
-```
+```text
 GET /api/cases
   → routes.py:57           list_case_ids()
     → data/__init__.py:43    load_isles_dataset()
       → loader.py:224        ds = load_dataset(...)  ← DOWNLOADS 27GB EAGERLY
 ```
 
-**The bug:** `datasets.load_dataset()` without `streaming=True` downloads ALL 149 parquet shards (~27GB) before returning. This takes 5-10+ minutes, causing HF Spaces proxy timeout.
+**The bug:** `datasets.load_dataset(dataset_id, split="train")` downloads/prepares the full
+dataset on cold start. On HF Spaces this regularly exceeds the proxy timeout window, so
+the frontend never receives a usable case list.
 
 ## Previous Misdiagnosis
 
@@ -27,7 +34,8 @@ This was identified in `ARCHITECTURE-AUDIT-2024-12-13.md` as P2-006 and dismisse
 
 > "Dataset reload per request | ACCEPTABLE | Demo scale (149 cases), adds negligible latency"
 
-**This assessment was wrong.** The latency isn't from "149 cases" - it's from downloading 27GB of parquet data to get those 149 case IDs.
+**This assessment was wrong.** The latency isn't from "149 cases"—it's from an eager
+27GB download/prepare step happening in the request path.
 
 ## Verified Facts
 
@@ -36,121 +44,60 @@ This was identified in `ARCHITECTURE-AUDIT-2024-12-13.md` as P2-006 and dismisse
 | Total download | 27.41 GB | `load_dataset_builder().info.download_size` |
 | Number of cases | 149 | `info.splits['train'].num_examples` |
 | Shards | 149 parquet files | HF Hub API |
-| Case ID pattern | `sub-stroke0001` to `sub-stroke0149` | Streaming sample confirmed sequential |
-| Case IDs are sequential | YES | First 10 match `sub-stroke{N:04d}` pattern |
+| Shard shape | 1 case per parquet file | `load_dataset(..., data_files={...})` returns 1 row |
+| Case ID range | `sub-stroke0001` … `sub-stroke0189` (with gaps) | subject_id per shard |
 
 ## The Fix
 
 ### Part 1: Instant Case List (No Download)
 
-**Problem:** `list_case_ids()` downloads 27GB to return 149 strings.
+**Problem:** `list_case_ids()` was implemented by loading the dataset, which on HF Spaces
+meant triggering the full 27GB download/prepare.
 
-**Solution:** Generate the list from dataset info (1 second, no download):
+**Solution:** Use a pinned manifest of case IDs for the ISLES24 dataset.
 
-```python
-# In data/__init__.py or routes.py
-def list_case_ids() -> list[str]:
-    """Return case IDs without downloading the dataset."""
-    from datasets import load_dataset_builder
-    from stroke_deepisles_demo.core.config import get_settings
+Implemented at `src/stroke_deepisles_demo/data/isles24_manifest.py` (pinned to dataset revision).
 
-    # Get count from metadata (no download)
-    builder = load_dataset_builder(get_settings().hf_dataset_id)
-    num_cases = builder.info.splits['train'].num_examples
+### Part 2: Per-Case Loading by Shard (No Full Download)
 
-    # Generate sequential IDs (verified pattern)
-    return [f'sub-stroke{str(i+1).zfill(4)}' for i in range(num_cases)]
-```
+**Problem:** `get_case(case_id)` previously loaded the whole dataset, even when only one
+case is needed for inference.
 
-**Why this works:**
-- `load_dataset_builder()` only fetches metadata (~1 second)
-- Case IDs are sequential `sub-stroke0001` through `sub-stroke0149` (verified)
-- Returns instantly instead of waiting for 27GB download
+**Solution:** For a single case, load exactly one Parquet shard using `data_files=...`,
+then materialize DWI/ADC (and optional lesion mask) to temp files.
 
-### Part 2: Lazy Single-Case Loading (Streaming)
+Implemented in `src/stroke_deepisles_demo/data/loader.py` as `Isles24HuggingFaceDataset`.
 
-**Problem:** `get_case(case_id)` downloads ALL 27GB to access ONE case (~180MB).
+### Why This Works on HF Spaces
 
-**Solution:** Use streaming mode to download only necessary shards:
-
-```python
-# In data/loader.py
-def load_single_case(case_id: str) -> dict:
-    """Load a single case using streaming (downloads only necessary shards)."""
-    from datasets import load_dataset
-    from stroke_deepisles_demo.core.config import get_settings
-
-    settings = get_settings()
-    ds = load_dataset(
-        settings.hf_dataset_id,
-        split='train',
-        streaming=True,
-        token=settings.hf_token,
-    )
-
-    # Filter for target case - stops downloading when found
-    for row in ds:
-        if row['subject_id'] == case_id:
-            return row
-
-    raise KeyError(f"Case {case_id} not found")
-```
-
-**Why this works:**
-- Streaming iterates through shards one at a time
-- Stops when target case is found
-- For case 50, downloads ~10 shards (~1.8GB) instead of all 149 (~27GB)
-- Still takes 30-120s depending on case position, but that's acceptable in background jobs
-
-### Part 3: Wire in Cache Directory (Persistence)
-
-**Problem:** `hf_cache_dir` setting exists but isn't used. Every cold start re-downloads.
-
-**Solution:** Pass cache_dir to load_dataset:
-
-```python
-ds = load_dataset(
-    settings.hf_dataset_id,
-    split='train',
-    streaming=True,
-    token=settings.hf_token,
-    cache_dir=settings.hf_cache_dir,  # ADD THIS
-)
-```
-
-**Why this works:**
-- HF Spaces can have persistent storage
-- First load is slow, subsequent loads use cache
-- Addresses P2-001 from REMAINING-ISSUES audit
+- `/api/cases` becomes a pure metadata response (fast, reliable).
+- Per-case data download happens in the background job (fits the async job model).
+- No streaming iteration over the full dataset is required.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `src/stroke_deepisles_demo/data/__init__.py` | Replace `list_case_ids()` with metadata-based implementation |
-| `src/stroke_deepisles_demo/data/loader.py` | Add streaming mode option, add `load_single_case()` function |
-| `src/stroke_deepisles_demo/api/routes.py` | Use new `list_case_ids()` (no change needed if interface same) |
+| `src/stroke_deepisles_demo/data/isles24_manifest.py` | Add pinned case ID manifest + shard mapping |
+| `src/stroke_deepisles_demo/data/loader.py` | Add `Isles24HuggingFaceDataset` + route ISLES24 loads to it |
 
 ## Implementation Steps
 
-1. **Update `list_case_ids()`** to use `load_dataset_builder().info` instead of loading data
-2. **Add `load_single_case(case_id)`** function using streaming + early termination
-3. **Update `get_case()`** to use `load_single_case()` instead of loading full dataset
-4. **Wire `cache_dir`** parameter through to all `load_dataset()` calls
-5. **Test locally** with cleared cache to simulate cold start
-6. **Deploy and verify** `/api/cases` returns in <5 seconds
+1. Add pinned ISLES24 case ID manifest (no download on `/api/cases`)
+2. Load single Parquet shard via `data_files=...` for `get_case(case_id)`
+3. Verify `/api/cases` returns immediately on HF Spaces
+4. Verify segmentation job downloads only selected case data
 
 ## Verification After Fix
 
 ```bash
 # After deploying fix, from cold start:
 time curl -s https://vibecodermcswaggins-stroke-deepisles-demo.hf.space/api/cases
-# Should complete in <5 seconds with {"cases": ["sub-stroke0001", ...]}
+# Should complete quickly with {"cases": ["sub-stroke0001", ...]}
 ```
 
 ## Notes
 
 - The full 27GB dataset IS supported - we're not reducing it
-- Case loading (30-120s) happens in background jobs, not blocking the API
-- This is the same pattern as before, just without the 27GB upfront download
-- The `neuroimaging-go-brrrr` package provides NIfTI support, but the core issue is the eager download
+- Case loading happens in background jobs, not blocking the API gateway timeout window
+- The core issue was doing full-dataset work inside `/api/cases`

--- a/docs/bugs/BUG-014-api-cases-500-error.md
+++ b/docs/bugs/BUG-014-api-cases-500-error.md
@@ -1,139 +1,156 @@
-# BUG-014: /api/cases Endpoint Timeout/500 Error
+# BUG-014: /api/cases Endpoint Timeout
 
-**Status**: ROOT CAUSE CONFIRMED
+**Status**: ROOT CAUSE CONFIRMED, FIX IDENTIFIED
 **Severity**: P1 (Frontend completely broken)
 **Discovered**: 2025-12-15
 **Reporter**: Manual testing
 
 ## Summary
 
-The `/api/cases` endpoint fails because it triggers a full 27GB dataset download on every request. This is an architectural design flaw, not a missing dependency or configuration issue.
+The `/api/cases` endpoint fails because it downloads the entire 27GB dataset just to return a list of 149 case IDs. This is fixable without reducing the dataset.
 
-## Verified Call Chain
+## Root Cause
 
+**Current code path:**
 ```
 GET /api/cases
-  → routes.py:57        list_case_ids()
-    → data/__init__.py:43  load_isles_dataset(source=source)
-      → loader.py:224      ds = load_dataset(dataset_id, split="train", token=hf_token)
-                           ↑ DOWNLOADS ENTIRE 27GB DATASET
+  → routes.py:57           list_case_ids()
+    → data/__init__.py:43    load_isles_dataset()
+      → loader.py:224        ds = load_dataset(...)  ← DOWNLOADS 27GB EAGERLY
 ```
 
-## Root Cause (Confirmed)
+**The bug:** `datasets.load_dataset()` without `streaming=True` downloads ALL 149 parquet shards (~27GB) before returning. This takes 5-10+ minutes, causing HF Spaces proxy timeout.
 
-**The `datasets.load_dataset()` call at `loader.py:224` downloads the entire dataset.**
+## Previous Misdiagnosis
 
-Dataset facts (verified via HF Hub API):
-- **Dataset ID**: `hugging-science/isles24-stroke`
-- **Size**: 149 parquet shards × ~184MB average = **~27.41GB total**
-- **Access**: PUBLIC (no auth required)
-- **Smallest shard**: 95.82MB
-- **Largest shard**: 260.09MB
+This was identified in `ARCHITECTURE-AUDIT-2024-12-13.md` as P2-006 and dismissed in `REMAINING-ISSUES-2024-12-13.md`:
 
-When `/api/cases` is called:
-1. `list_case_ids()` calls `load_isles_dataset()`
-2. `load_isles_dataset()` calls HuggingFace's `load_dataset()`
-3. `load_dataset()` downloads ALL 149 parquet shards (~27GB)
-4. This takes 5-10+ minutes on HF Spaces network
-5. HF Spaces proxy timeout (60-120s) kills the request
-6. Frontend sees timeout or 500 error
+> "Dataset reload per request | ACCEPTABLE | Demo scale (149 cases), adds negligible latency"
 
-## Evidence
+**This assessment was wrong.** The latency isn't from "149 cases" - it's from downloading 27GB of parquet data to get those 149 case IDs.
 
-| Test | Result |
-|------|--------|
-| `GET /` (health) | 200 OK in ~143s after cold start |
-| `GET /health` | 200 OK in ~286s after cold start |
-| `GET /api/cases` | Timeout after 300s (curl max-time) |
-| CORS headers | Present and correct |
-| Dataset public? | Yes, no token required |
+## Verified Facts
 
-The health endpoints work because they don't touch the dataset. The `/api/cases` endpoint fails because it's the first endpoint that triggers `load_isles_dataset()`.
+| Fact | Value | Verification |
+|------|-------|--------------|
+| Total download | 27.41 GB | `load_dataset_builder().info.download_size` |
+| Number of cases | 149 | `info.splits['train'].num_examples` |
+| Shards | 149 parquet files | HF Hub API |
+| Case ID pattern | `sub-stroke0001` to `sub-stroke0149` | Streaming sample confirmed sequential |
+| Case IDs are sequential | YES | First 10 match `sub-stroke{N:04d}` pattern |
 
-## Why HF Space Logs Won't Help
+## The Fix
 
-The logs show:
-```
-INFO: Application startup complete.
-INFO: 10.16.9.169:20572 - "GET /health HTTP/1.1" 200 OK
-```
+### Part 1: Instant Case List (No Download)
 
-We don't see `/api/cases` logged because:
-1. Uvicorn logs requests AFTER response is sent
-2. The request never completes (times out at proxy)
-3. No Python exception is raised (still downloading)
+**Problem:** `list_case_ids()` downloads 27GB to return 149 strings.
 
-We have enough information - logs would only confirm what we already know.
+**Solution:** Generate the list from dataset info (1 second, no download):
 
-## Why This Passed Local Testing
-
-Local development likely used:
-1. Cached dataset from previous runs
-2. Faster local disk I/O
-3. No HF Spaces proxy timeout
-4. Different network conditions
-
-## Architectural Flaw
-
-The design assumes `datasets.load_dataset()` is fast/cached. On HF Spaces:
-- Cold starts have empty cache
-- `/tmp` storage is limited and ephemeral
-- Downloading 27GB for a simple case list is not viable
-
-## Fix Options
-
-### Option A: Use a Small Demo Dataset (Recommended)
-Create a curated HF dataset with 5-10 representative cases (~500MB).
-- Fastest to implement
-- Reliable for demos
-- Clear scope
-
-### Option B: Streaming Mode
-Use `datasets.load_dataset(..., streaming=True)` to avoid full download.
-- Requires refactoring `HuggingFaceDatasetWrapper`
-- May still have performance issues for random case access
-
-### Option C: Direct HF Hub API
-Call HF Hub API directly to get case list from metadata without downloading data.
 ```python
-from huggingface_hub import HfApi
-api = HfApi()
-# Get dataset info without downloading
-info = api.dataset_info("hugging-science/isles24-stroke")
+# In data/__init__.py or routes.py
+def list_case_ids() -> list[str]:
+    """Return case IDs without downloading the dataset."""
+    from datasets import load_dataset_builder
+    from stroke_deepisles_demo.core.config import get_settings
+
+    # Get count from metadata (no download)
+    builder = load_dataset_builder(get_settings().hf_dataset_id)
+    num_cases = builder.info.splits['train'].num_examples
+
+    # Generate sequential IDs (verified pattern)
+    return [f'sub-stroke{str(i+1).zfill(4)}' for i in range(num_cases)]
 ```
-- More complex implementation
-- Decouples metadata from data access
 
-### Option D: Pre-computed Case List
-Hardcode or cache the case ID list, load individual cases on demand.
-- Simple but requires knowing case IDs in advance
-- Doesn't scale if dataset changes
+**Why this works:**
+- `load_dataset_builder()` only fetches metadata (~1 second)
+- Case IDs are sequential `sub-stroke0001` through `sub-stroke0149` (verified)
+- Returns instantly instead of waiting for 27GB download
 
-## Recommendation
+### Part 2: Lazy Single-Case Loading (Streaming)
 
-**Option A (small demo dataset)** is the cleanest fix for a demo application. The 27GB medical imaging dataset is production-scale data that shouldn't be loaded on every API request.
+**Problem:** `get_case(case_id)` downloads ALL 27GB to access ONE case (~180MB).
 
-## Files Requiring Changes
+**Solution:** Use streaming mode to download only necessary shards:
+
+```python
+# In data/loader.py
+def load_single_case(case_id: str) -> dict:
+    """Load a single case using streaming (downloads only necessary shards)."""
+    from datasets import load_dataset
+    from stroke_deepisles_demo.core.config import get_settings
+
+    settings = get_settings()
+    ds = load_dataset(
+        settings.hf_dataset_id,
+        split='train',
+        streaming=True,
+        token=settings.hf_token,
+    )
+
+    # Filter for target case - stops downloading when found
+    for row in ds:
+        if row['subject_id'] == case_id:
+            return row
+
+    raise KeyError(f"Case {case_id} not found")
+```
+
+**Why this works:**
+- Streaming iterates through shards one at a time
+- Stops when target case is found
+- For case 50, downloads ~10 shards (~1.8GB) instead of all 149 (~27GB)
+- Still takes 30-120s depending on case position, but that's acceptable in background jobs
+
+### Part 3: Wire in Cache Directory (Persistence)
+
+**Problem:** `hf_cache_dir` setting exists but isn't used. Every cold start re-downloads.
+
+**Solution:** Pass cache_dir to load_dataset:
+
+```python
+ds = load_dataset(
+    settings.hf_dataset_id,
+    split='train',
+    streaming=True,
+    token=settings.hf_token,
+    cache_dir=settings.hf_cache_dir,  # ADD THIS
+)
+```
+
+**Why this works:**
+- HF Spaces can have persistent storage
+- First load is slow, subsequent loads use cache
+- Addresses P2-001 from REMAINING-ISSUES audit
+
+## Files to Change
 
 | File | Change |
 |------|--------|
-| `src/stroke_deepisles_demo/core/config.py` | Update `hf_dataset_id` default |
-| `pyproject.toml` | No changes needed |
-| New HF Dataset | Create `VibecoderMcSwaggins/isles24-demo` with 5-10 cases |
+| `src/stroke_deepisles_demo/data/__init__.py` | Replace `list_case_ids()` with metadata-based implementation |
+| `src/stroke_deepisles_demo/data/loader.py` | Add streaming mode option, add `load_single_case()` function |
+| `src/stroke_deepisles_demo/api/routes.py` | Use new `list_case_ids()` (no change needed if interface same) |
 
-## Verification Steps After Fix
+## Implementation Steps
+
+1. **Update `list_case_ids()`** to use `load_dataset_builder().info` instead of loading data
+2. **Add `load_single_case(case_id)`** function using streaming + early termination
+3. **Update `get_case()`** to use `load_single_case()` instead of loading full dataset
+4. **Wire `cache_dir`** parameter through to all `load_dataset()` calls
+5. **Test locally** with cleared cache to simulate cold start
+6. **Deploy and verify** `/api/cases` returns in <5 seconds
+
+## Verification After Fix
 
 ```bash
-# 1. Deploy updated backend to HF Spaces
-# 2. Wait for cold start to complete
-# 3. Test:
-curl -s https://vibecodermcswaggins-stroke-deepisles-demo.hf.space/api/cases
-# Should return {"cases": ["sub-stroke0001", ...]} within 5-10 seconds
+# After deploying fix, from cold start:
+time curl -s https://vibecodermcswaggins-stroke-deepisles-demo.hf.space/api/cases
+# Should complete in <5 seconds with {"cases": ["sub-stroke0001", ...]}
 ```
 
 ## Notes
 
-- This bug was always present but masked by local caching
-- Frontend fix (Static SDK deployment) exposed the backend issue
-- The 500 error is actually a timeout converted to error by HF proxy
-- No code changes were made to cause this - it's a deployment environment difference
+- The full 27GB dataset IS supported - we're not reducing it
+- Case loading (30-120s) happens in background jobs, not blocking the API
+- This is the same pattern as before, just without the 27GB upfront download
+- The `neuroimaging-go-brrrr` package provides NIfTI support, but the core issue is the eager download

--- a/docs/specs/00-data-loading-refactor.md
+++ b/docs/specs/00-data-loading-refactor.md
@@ -8,6 +8,11 @@
 
 ## Problem Statement
 
+> **Update (2025-12-15):** HF Spaces requires avoiding eager full-dataset downloads.
+> The implementation now uses a pinned ISLES24 manifest (`src/stroke_deepisles_demo/data/isles24_manifest.py`)
+> for `/api/cases`, and loads a single case via `datasets.load_dataset(..., data_files=...)` (one Parquet shard)
+> instead of `load_dataset(..., split="train")`.
+
 `stroke-deepisles-demo` has a hand-rolled data loading workaround that:
 
 1. **Bypasses `datasets.load_dataset()`** - Uses `HfFileSystem + pyarrow` directly

--- a/src/stroke_deepisles_demo/data/isles24_manifest.py
+++ b/src/stroke_deepisles_demo/data/isles24_manifest.py
@@ -1,0 +1,189 @@
+"""ISLES'24 Stroke dataset manifest for Hugging Face loading.
+
+This project targets the Hugging Face dataset repo `hugging-science/isles24-stroke`.
+On HF Spaces, calling `datasets.load_dataset(dataset_id, split="train")` can trigger
+an eager download/prepare step for ~27GB of Parquet shards, which is not viable for
+fast API endpoints like `/api/cases`.
+
+The upstream dataset stores one case per Parquet file at:
+`data/train-00000-of-00149.parquet` ... `data/train-00148-of-00149.parquet`
+
+This manifest provides:
+- The authoritative list of available case IDs (subject_ids) for the train split.
+- A stable mapping from case ID → Parquet shard index (and thus data file path).
+
+SSOT:
+- Generated from the dataset at the pinned revision below by reading `subject_id`
+  from each Parquet file (without downloading the full dataset).
+"""
+
+from __future__ import annotations
+
+ISLES24_DATASET_ID = "hugging-science/isles24-stroke"
+# Pinned to the dataset revision used to generate this manifest.
+ISLES24_DATASET_REVISION = "9707a7fca6d3dd1a690de010ec4aed06bdcd0417"
+
+ISLES24_TRAIN_NUM_FILES = 149
+
+# Case IDs in the same order as the Parquet shard filenames (train-00000..., train-00001..., ...).
+ISLES24_TRAIN_CASE_IDS: tuple[str, ...] = (
+    "sub-stroke0001",
+    "sub-stroke0002",
+    "sub-stroke0003",
+    "sub-stroke0004",
+    "sub-stroke0005",
+    "sub-stroke0006",
+    "sub-stroke0007",
+    "sub-stroke0008",
+    "sub-stroke0009",
+    "sub-stroke0010",
+    "sub-stroke0011",
+    "sub-stroke0012",
+    "sub-stroke0013",
+    "sub-stroke0014",
+    "sub-stroke0015",
+    "sub-stroke0016",
+    "sub-stroke0017",
+    "sub-stroke0019",
+    "sub-stroke0020",
+    "sub-stroke0021",
+    "sub-stroke0022",
+    "sub-stroke0025",
+    "sub-stroke0026",
+    "sub-stroke0027",
+    "sub-stroke0028",
+    "sub-stroke0030",
+    "sub-stroke0033",
+    "sub-stroke0036",
+    "sub-stroke0037",
+    "sub-stroke0038",
+    "sub-stroke0040",
+    "sub-stroke0043",
+    "sub-stroke0045",
+    "sub-stroke0047",
+    "sub-stroke0048",
+    "sub-stroke0049",
+    "sub-stroke0052",
+    "sub-stroke0053",
+    "sub-stroke0054",
+    "sub-stroke0055",
+    "sub-stroke0057",
+    "sub-stroke0062",
+    "sub-stroke0066",
+    "sub-stroke0068",
+    "sub-stroke0070",
+    "sub-stroke0071",
+    "sub-stroke0073",
+    "sub-stroke0074",
+    "sub-stroke0075",
+    "sub-stroke0076",
+    "sub-stroke0077",
+    "sub-stroke0078",
+    "sub-stroke0079",
+    "sub-stroke0080",
+    "sub-stroke0081",
+    "sub-stroke0082",
+    "sub-stroke0083",
+    "sub-stroke0084",
+    "sub-stroke0085",
+    "sub-stroke0086",
+    "sub-stroke0087",
+    "sub-stroke0088",
+    "sub-stroke0089",
+    "sub-stroke0090",
+    "sub-stroke0091",
+    "sub-stroke0092",
+    "sub-stroke0093",
+    "sub-stroke0094",
+    "sub-stroke0095",
+    "sub-stroke0096",
+    "sub-stroke0097",
+    "sub-stroke0098",
+    "sub-stroke0099",
+    "sub-stroke0100",
+    "sub-stroke0101",
+    "sub-stroke0102",
+    "sub-stroke0103",
+    "sub-stroke0104",
+    "sub-stroke0105",
+    "sub-stroke0106",
+    "sub-stroke0107",
+    "sub-stroke0108",
+    "sub-stroke0109",
+    "sub-stroke0110",
+    "sub-stroke0111",
+    "sub-stroke0112",
+    "sub-stroke0113",
+    "sub-stroke0114",
+    "sub-stroke0115",
+    "sub-stroke0116",
+    "sub-stroke0117",
+    "sub-stroke0118",
+    "sub-stroke0119",
+    "sub-stroke0133",
+    "sub-stroke0134",
+    "sub-stroke0135",
+    "sub-stroke0136",
+    "sub-stroke0137",
+    "sub-stroke0138",
+    "sub-stroke0139",
+    "sub-stroke0140",
+    "sub-stroke0141",
+    "sub-stroke0142",
+    "sub-stroke0143",
+    "sub-stroke0144",
+    "sub-stroke0145",
+    "sub-stroke0146",
+    "sub-stroke0147",
+    "sub-stroke0148",
+    "sub-stroke0149",
+    "sub-stroke0150",
+    "sub-stroke0151",
+    "sub-stroke0152",
+    "sub-stroke0153",
+    "sub-stroke0154",
+    "sub-stroke0155",
+    "sub-stroke0156",
+    "sub-stroke0157",
+    "sub-stroke0158",
+    "sub-stroke0159",
+    "sub-stroke0161",
+    "sub-stroke0162",
+    "sub-stroke0163",
+    "sub-stroke0164",
+    "sub-stroke0165",
+    "sub-stroke0166",
+    "sub-stroke0167",
+    "sub-stroke0168",
+    "sub-stroke0169",
+    "sub-stroke0170",
+    "sub-stroke0171",
+    "sub-stroke0172",
+    "sub-stroke0173",
+    "sub-stroke0174",
+    "sub-stroke0175",
+    "sub-stroke0176",
+    "sub-stroke0177",
+    "sub-stroke0178",
+    "sub-stroke0179",
+    "sub-stroke0180",
+    "sub-stroke0181",
+    "sub-stroke0182",
+    "sub-stroke0183",
+    "sub-stroke0184",
+    "sub-stroke0185",
+    "sub-stroke0186",
+    "sub-stroke0187",
+    "sub-stroke0188",
+    "sub-stroke0189",
+)
+
+ISLES24_TRAIN_CASE_ID_TO_FILE_INDEX: dict[str, int] = {
+    case_id: idx for idx, case_id in enumerate(ISLES24_TRAIN_CASE_IDS)
+}
+
+
+def isles24_train_data_file(case_id: str) -> str:
+    """Return the Parquet data file path in the HF dataset repo for a given case ID."""
+    idx = ISLES24_TRAIN_CASE_ID_TO_FILE_INDEX[case_id]
+    return f"data/train-{idx:05d}-of-{ISLES24_TRAIN_NUM_FILES:05d}.parquet"

--- a/tests/data/test_isles24_dataset.py
+++ b/tests/data/test_isles24_dataset.py
@@ -1,0 +1,78 @@
+"""Unit tests for ISLES24 HF dataset fast-path loader."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from stroke_deepisles_demo.data.isles24_manifest import (
+    ISLES24_DATASET_ID,
+    ISLES24_DATASET_REVISION,
+    ISLES24_TRAIN_CASE_IDS,
+    isles24_train_data_file,
+)
+from stroke_deepisles_demo.data.loader import Isles24HuggingFaceDataset
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_list_case_ids_returns_manifest() -> None:
+    dataset = Isles24HuggingFaceDataset()
+    assert dataset.list_case_ids() == list(ISLES24_TRAIN_CASE_IDS)
+    assert len(dataset) == len(ISLES24_TRAIN_CASE_IDS)
+
+
+def test_get_case_loads_single_parquet_shard(tmp_path: Path) -> None:
+    mock_dwi = MagicMock()
+    mock_adc = MagicMock()
+
+    mock_ds = MagicMock()
+    mock_ds.select_columns.return_value = mock_ds
+    mock_ds.__len__.return_value = 1
+    mock_ds.__getitem__.return_value = {
+        "subject_id": "sub-stroke0001",
+        "dwi": mock_dwi,
+        "adc": mock_adc,
+        "lesion_mask": None,
+    }
+
+    temp_root = tmp_path / "hf_tmp"
+    temp_root.mkdir()
+
+    with (
+        patch("datasets.load_dataset", return_value=mock_ds) as mock_load,
+        patch("stroke_deepisles_demo.data.loader.tempfile.mkdtemp", return_value=str(temp_root)),
+    ):
+        dataset = Isles24HuggingFaceDataset(token="hf_token_123")
+        with dataset:
+            case = dataset.get_case("sub-stroke0001")
+
+    # Uses pinned dataset settings + per-shard data_files selection.
+    mock_load.assert_called_once_with(
+        ISLES24_DATASET_ID,
+        data_files={"train": isles24_train_data_file("sub-stroke0001")},
+        split="train",
+        token="hf_token_123",
+        revision=ISLES24_DATASET_REVISION,
+    )
+
+    assert case["dwi"].name == "sub-stroke0001_dwi.nii.gz"
+    assert case["adc"].name == "sub-stroke0001_adc.nii.gz"
+    assert case["dwi"].parent == temp_root / "sub-stroke0001"
+    assert case["adc"].parent == temp_root / "sub-stroke0001"
+
+    # Materializes NIfTI objects via to_filename().
+    assert mock_dwi.to_filename.call_count == 1
+    assert mock_adc.to_filename.call_count == 1
+
+    # Temp dir cleaned up by context manager.
+    assert not temp_root.exists()
+
+
+def test_get_case_rejects_unknown_case_id() -> None:
+    dataset = Isles24HuggingFaceDataset()
+    with pytest.raises(KeyError):
+        _ = dataset.get_case("sub-stroke9999")


### PR DESCRIPTION
## Summary

- **Root cause**: `datasets.load_dataset(dataset_id, split="train")` downloads the entire 27GB ISLES24 dataset on cold start, causing HF Spaces proxy timeouts on `/api/cases`
- **Fix**: Add pinned manifest + per-shard loading so `/api/cases` returns instantly and `get_case()` downloads only one Parquet shard (~180MB)

## Changes

| File | Change |
|------|--------|
| `src/stroke_deepisles_demo/data/isles24_manifest.py` | New: Pinned manifest of 149 case IDs with shard mapping |
| `src/stroke_deepisles_demo/data/loader.py` | Add `Isles24HuggingFaceDataset` class + route ISLES24 loads to it |
| `tests/data/test_isles24_dataset.py` | New: Unit tests for the optimized loader |
| `tests/data/test_loader.py` | Update tests for new routing |
| `docs/bugs/BUG-014-api-cases-500-error.md` | Update bug doc with implemented fix |

## Verification

- All 161 tests pass
- Local verification shows `load_isles_dataset()` returns `Isles24HuggingFaceDataset`
- `list_case_ids()` returns 149 cases instantly from manifest

## Test plan

- [ ] Verify `/api/cases` returns instantly on HF Spaces cold start
- [ ] Verify segmentation job downloads only selected case data
- [ ] CodeRabbit review

Closes BUG-014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API /cases now returns metadata instantly instead of timing out during dataset access.

* **New Features**
  * Pinned manifest and per-case shard loading enable fast metadata responses and on-demand per-case data retrieval without full dataset downloads; per-case loads occur in background.

* **Documentation**
  * Updated docs explaining the HF Spaces-safe loading approach and verification steps.

* **Tests**
  * Added/updated unit tests covering the fast-path per-case loader and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->